### PR TITLE
scripts: apply realpath for $0

### DIFF
--- a/src/groebner/script.template
+++ b/src/groebner/script.template
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. 
 
 # We locate where this script is so we can call the executables.
-SCRIPT=`which "$0"`
+SCRIPT=$(realpath $(which "$0"))
 DIR=`dirname "$SCRIPT"`
 FUNCTION=`basename "$SCRIPT"`
 

--- a/src/groebner/script.template.in
+++ b/src/groebner/script.template.in
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. 
 
 # We locate where this script is so we can call the executables.
-SCRIPT=`which "$0"`
+SCRIPT=$(realpath $(which "$0"))
 DIR=`dirname "$SCRIPT"`
 FUNCTION=`basename "$SCRIPT"`
 

--- a/src/zsolve/graver.template
+++ b/src/zsolve/graver.template
@@ -2,7 +2,7 @@
 
 # We locate where this script is so we can call the executable zsolve which
 # should be in the same directory as this script.
-SCRIPT=`which "$0"`
+SCRIPT=$(realpath $(which "$0"))
 SCRIPTDIR=`dirname "$SCRIPT"`
 EXECUTABLE=zsolve
 

--- a/src/zsolve/hilbert.template
+++ b/src/zsolve/hilbert.template
@@ -2,7 +2,7 @@
 
 # We locate where this script is so we can call the executable zsolve which
 # should be in the same directory as this script.
-SCRIPT=`which "$0"`
+SCRIPT=$(realpath $(which "$0"))
 SCRIPTDIR=`dirname "$SCRIPT"`
 EXECUTABLE=zsolve
 


### PR DESCRIPTION
When $0 is a symlink, program execution would fail to find the right
directory. Fix that up.

The 4ti2 program names are quite generic (e.g. "output"), and hence
openSUSE has relegated them to /usr/libexec/4ti2, offering instead
prefixed symlinks in /usr/bin, e.g. /usr/bin/4ti2_groebner ->
/usr/libexec/4ti2/groebner.