### PR TITLE
Fix bashishms in m4 scripts

### DIFF
--- a/m4/glpk-check.m4
+++ b/m4/glpk-check.m4
@@ -34,7 +34,7 @@ AC_MSG_CHECKING(for GLPK's glp_ API)
 
 for GLPK_HOME in ${GLPK_HOME_PATH} 
   do	
-	if test "x$GLPK_HOME" == "xDEFAULT" -o -r "$GLPK_HOME/include/glpk.h"; then
+	if test "x$GLPK_HOME" = "xDEFAULT" -o -r "$GLPK_HOME/include/glpk.h"; then
 
 		if test "x$GLPK_HOME" != "xDEFAULT" ; then
 			GLPK_CFLAGS="-I${GLPK_HOME}/include"

--- a/m4/gmp-check.m4
+++ b/m4/gmp-check.m4
@@ -36,7 +36,7 @@ AC_MSG_CHECKING(for GMP >= $min_gmp_version)
 
 for GMP_HOME in ${GMP_HOME_PATH} 
   do	
-	if test "x$GMP_HOME" == "xDEFAULT" -o -r "$GMP_HOME/include/gmp.h"; then
+	if test "x$GMP_HOME" = "xDEFAULT" -o -r "$GMP_HOME/include/gmp.h"; then
 
 		if test "x$GMP_HOME" != "xDEFAULT" ; then
 			GMP_CFLAGS="-I${GMP_HOME}/include"


### PR DESCRIPTION
POSIX shell requires =, not == for string comparison.

The first commit only fixed configure.ac, but there were more occurrences in m4 files.

Fixes: 126af10273d0 (`"Use = with test, not == (bashism)"`)