### PR TITLE
Fix memory leak in permuteListVector

### DIFF
--- a/src/util/vector.c
+++ b/src/util/vector.c
@@ -525,7 +525,7 @@ listVector* permuteListVector(listVector* LIST, vector p, int numOfVars) {
   listVector *tmp2;
 
   tmp2=LIST;
-  v=createVector(numOfVars);
+  v=0;
   while (LIST) {
     tmp=LIST->first;
     v=permuteVector(LIST->first,p,numOfVars);


### PR DESCRIPTION
The malloc'd vector pointer here is not free'd and overwritten 3 lines below in `v=permuteVector(LIST->first,p,numOfVars);`.

Just a small issue I found while scanning Debian packages for memory leaks.