### PR TITLE
build: resolve missing includes showing on gcc-13

### DIFF
--- a/src/zsolve/VectorArrayAPI.hpp
+++ b/src/zsolve/VectorArrayAPI.hpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #include "zsolve/VectorArray.hpp"
 #include "zsolve/Exception.h"
 #include <fstream>
+#include <cstdint>
 #include <cstdlib>
 
 namespace _4ti2_zsolve_ {


### PR DESCRIPTION
```
../../src/zsolve/VectorArrayAPI.hpp: In function 'void _4ti2_zsolve_::convert(const T1&, T2&) [with T1 = long int; T2 = int]':
../../src/zsolve/VectorArrayAPI.hpp:79:14: error: 'INT32_MIN' was not declared in this scope; did you mean 'INT_MIN'?
```