### PR TITLE
make autogen_sh works without swig folder

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,5 +3,6 @@ aclocal -I m4
 autoheader
 autoconf
 libtoolize --force || glibtoolize --force
+mkdir -p swig
 automake --add-missing
-(cd swig && sh ./autogen.sh)
+(test -e swig/autogen.sh && cd swig && sh ./autogen.sh)


### PR DESCRIPTION
This patch allows us to regenerate the autotools material in the absence of the `swig' directory.