### PR TITLE
replace use of PATH_MAX by asprintf

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+## gnulib-tool --import --lib=libgnu --source-base=lib --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=. --no-conditional-dependencies --no-libtool --macro-prefix=gl vasprintf getopt-gnu
+gnulib-tool --update
 aclocal -I m4
 autoheader
 autoconf

--- a/m4/gnulib-cache.m4
+++ b/m4/gnulib-cache.m4
@@ -1,8 +1,8 @@
-# Copyright (C) 2002-2013 Free Software Foundation, Inc.
+# Copyright (C) 2002-2025 Free Software Foundation, Inc.
 #
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This file is distributed in the hope that it will be useful,
@@ -11,7 +11,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this file.  If not, see <http://www.gnu.org/licenses/>.
+# along with this file.  If not, see <https://www.gnu.org/licenses/>.
 #
 # As a special exception to the GNU General Public License,
 # this file may be distributed as part of a program that
@@ -27,11 +27,23 @@
 
 
 # Specification in the form of a command-line invocation:
-#   gnulib-tool --import --dir=. --lib=libgnu --source-base=lib --m4-base=m4 --doc-base=doc --tests-base=tests --aux-dir=. --no-conditional-dependencies --no-libtool --macro-prefix=gl getopt-gnu
+# gnulib-tool --import \
+#  --lib=libgnu \
+#  --source-base=lib \
+#  --m4-base=m4 \
+#  --doc-base=doc \
+#  --tests-base=tests \
+#  --aux-dir=. \
+#  --no-conditional-dependencies \
+#  --no-libtool \
+#  --macro-prefix=gl \
+#  vasprintf \
+#  getopt-gnu
 
 # Specification in the form of a few gnulib-tool.m4 macro invocations:
 gl_LOCAL_DIR([])
 gl_MODULES([
+  vasprintf
   getopt-gnu
 ])
 gl_AVOID([])

--- a/src/util/gensymm.c
+++ b/src/util/gensymm.c
@@ -29,19 +29,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 /* Created    : 26-AUG-02                                            */
 /*                                                                   */
 /* ----------------------------------------------------------------- */
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
-#include <limits.h>
 #include "myheader.h"
 #include "print.h"
 #include "vector.h"
 
 #include <getopt.h>
 #include "banner.h"
-
-#ifndef PATH_MAX
-#define PATH_MAX FILENAME_MAX
-#endif
 
 /* ----------------------------------------------------------------- */
 void printPermutationToFile(FILE *out, vector v, int numOfVars) {
@@ -104,7 +100,8 @@ static void print_usage()
 int gensymm_main(int argc, char *argv[]) {
   int a,i,j,k,l,x,y,z,w,numOfVars,numOfGenerators,infoLevel;
   vector v;
-  char fileName[PATH_MAX],outFileName[PATH_MAX];
+  const char *fileName=NULL;
+	char *outFileName=NULL;
   FILE *out;
 
   int optc;
@@ -143,7 +140,7 @@ int gensymm_main(int argc, char *argv[]) {
 
 /* We require that all 1's come last in the tuple (x,y,z,w). */
 
-  strcpy(fileName,argv[argc-1]);
+  fileName=argv[argc-1];
   x=atoi(argv[argc-5]);
   y=atoi(argv[argc-4]);
   z=atoi(argv[argc-3]);
@@ -169,11 +166,11 @@ int gensymm_main(int argc, char *argv[]) {
 
 /* Now we are back in business. */
 
-  strcpy(outFileName,fileName);
-  strcat(outFileName,".sym");
+  myxasprintf(&outFileName,"%s.sym",fileName);
 
+  errno=0;
   if (!(out = fopen(outFileName,"w"))) {
-    printf("Error opening generator file for output.");
+    printf("Error opening generator file for output (%s).\n",strerror(errno));
     exit (0);
   }
 
@@ -395,6 +392,9 @@ int gensymm_main(int argc, char *argv[]) {
     printPermutationToFile(out, v, numOfVars);
   }
 
+  fclose(out);
+
+  free(outFileName);
 
   return(0);
 }

--- a/src/util/myheader.h
+++ b/src/util/myheader.h
@@ -20,6 +20,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. 
 */
 
+#include <errno.h>
 #include <stdio.h>
 #include <math.h>
 //#include <malloc.h>
@@ -160,3 +161,12 @@ typedef struct listSignPatternPair {
   struct listSignPatternPair* rest;
 }
 listSignPatternPair;
+
+
+#define myxasprintf(fILEnANEpTR,fORMAT,...) { \
+    errno=0; \
+    if (asprintf(fILEnANEpTR,fORMAT,__VA_ARGS__) < 0) { \
+      printf("Error allocating file name (%s).\n",strerror(errno)); \
+      exit(0); \
+    } \
+  }

--- a/src/util/print.c
+++ b/src/util/print.c
@@ -28,16 +28,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 /* Co-Author: Ralf Hemmecke      (data structure, code optimization) */
 /*                                                                   */
 /*------------------------------------------------------------------ */
-#include "../banner.h"
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include "banner.h"
 #include "myheader.h"
 #include "orbit.h"
 #include "vector.h"
-#include <stdlib.h>
-#include <limits.h>
-
-#ifndef PATH_MAX
-#define PATH_MAX FILENAME_MAX
-#endif
 
 /* ----------------------------------------------------------------- */
 void printVersionInfo() {
@@ -765,51 +762,42 @@ void printListVectorWithGivenNonzeroEntryToFile(char *outFileName,
 /* ----------------------------------------------------------------- */
 void writeResult(listVector *basis, int numOfVars, char *fileName, 
 		 char *basisType, int infoLevel) {
-  char outFileName[PATH_MAX];
+  const char *infoMessage="undefined";
+  const char *outExtension="";
+  char *outFileName=NULL;
+  int noskip=1;
 
   /* Write result to screen and files. */
 
-if (infoLevel>0) {
-  printf("Writing result to files: ");
-}
-  /* Write Graver basis file. */
-  if (basisType[0]=='g') {
-if (infoLevel>0) {
-    printf("Graver basis elements: %d\n\n",lengthListVector(basis));
-}
-    strcpy(outFileName,fileName);
-    printListVectorToFile(outFileName,basis,numOfVars);
-  } 
-
-  /* Write Hilbert basis file. */
-  if (basisType[0]=='h') {
-if (infoLevel>0) {
-    printf("Hilbert basis elements: %d\n\n",lengthListVector(basis));
-}
-
-    strcpy(outFileName,fileName);
-    printListVectorToFile(outFileName,basis,numOfVars);
+  switch (basisType[0]) {
+  case 'g': /* Write Graver basis file. */
+	  infoMessage="Graver basis elements";
+    /* outExtension=""; */
+    break;
+  case 'h': /* Write Hilbert basis file. */
+	  infoMessage="Hilbert basis elements";
+    /* outExtension=""; */
+    break;
+  case 'd': /* Write Hilbert basis file of dual cone. */
+	  infoMessage="Hilbert basis elements";
+    outExtension=".dual.hil";
+    break;
+  case 'r': /* Write extreme rays file. */
+	  infoMessage="Extreme rays";
+    outExtension=".ray";
+    break;
+  default:
+    noskip=0;
+    break;
   }
 
-  /* Write Hilbert basis file of dual cone. */
-  if (basisType[0]=='d') {
-if (infoLevel>0) {
-    printf("Hilbert basis elements: %d\n\n",lengthListVector(basis));
-}
-
-    strcpy(outFileName,fileName);
-    strcat(outFileName,".dual.hil");
+  if (noskip) {
+    if (infoLevel>0) {
+      printf("Writing result to files: %s: %d\n\n",infoMessage,lengthListVector(basis));
+    }
+    myxasprintf(&outFileName,"%s%s",fileName,outExtension);
     printListVectorToFile(outFileName,basis,numOfVars);
-  }
-
-  /* Write extreme rays file. */
-  if (basisType[0]=='r') {
-if (infoLevel>0) {
-    printf("Extreme rays: %d\n\n",lengthListVector(basis));
-}
-    strcpy(outFileName,fileName);
-    strcat(outFileName,".ray");
-    printListVectorToFile(outFileName,basis,numOfVars);
+    free(outFileName);
   }
 
   return;


### PR DESCRIPTION
This patch fixes the buffer overflow vulnerabilities in filename management as reported in Debian bugreport [#915571](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=915571) and in #14. However, instead of replacing the `strcpy' and `strcat' with their respective counterparts `strncpy' and `strncat', it uses the safer `asprintf' wrt to the recommendation to the GNU gcc manual.