### PR TITLE
src/zsolve/DefaultController.hpp: Remove secret 'maxnorm == 2' option handling

### DIFF
--- a/src/zsolve/DefaultController.hpp
+++ b/src/zsolve/DefaultController.hpp
@@ -252,7 +252,7 @@ public:
 
     void log_maxnorm (Algorithm <T> * algorithm, bool final)
     {
-        if ((m_options.maxnorm () == 1 && final) || m_options.maxnorm () == 2)
+        if (m_options.maxnorm () && final)
         {
             VectorArray <T> maxnorm (algorithm->get_result_variables ());
             T norm = algorithm->extract_maxnorm_results (maxnorm);


### PR DESCRIPTION
- Fixes #51
