### PR TITLE
fix timer-related code for MINGW64 / MSYS2

### DIFF
--- a/src/groebner/Timer.cpp
+++ b/src/groebner/Timer.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 #include <unistd.h>
 #include <ctime>
-#ifdef _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
 #include <sys/times.h>
 #endif
 #include <iomanip>
@@ -53,7 +53,7 @@ Timer::get_elapsed_time() const
 double
 Timer::get_time()
 {
-#if defined _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
     struct tms t;
     times(&t); 
     return (double) t.tms_utime/sysconf(_SC_CLK_TCK);

--- a/src/ppi/ppi.cpp
+++ b/src/ppi/ppi.cpp
@@ -44,7 +44,7 @@
 using namespace std;
 
 // Timer stuff taken from src/zsolve/cputime.c
-#ifdef _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
 #include <sys/time.h>
 #include <sys/resource.h>
 #endif
@@ -52,7 +52,7 @@ using namespace std;
 
 double getCPUTime()
 {
-#ifdef _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
 	struct rusage usage;
 
 	getrusage(RUSAGE_SELF, &usage);

--- a/src/zsolve/Timer.cpp
+++ b/src/zsolve/Timer.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 #include <unistd.h>
 #include <ctime>
-#ifdef _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
 #include <sys/times.h>
 #endif
 #include <iomanip>
@@ -50,7 +50,7 @@ double Timer::get_elapsed_time() const
 
 double Timer::get_time()
 {
-#if defined _POSIX_TIMERS
+#if defined(_POSIX_TIMERS) && !defined(__MINGW64__)
     struct tms t;
     times(&t); 
     return (double) t.tms_utime/sysconf(_SC_CLK_TCK);


### PR DESCRIPTION
MINGW64 does not have the `<sys/times.h>` and `<sys/resource.h>` headers, thus compilation of 4ti2 fails there. This introduces a patch which is currently used by the MSYS2 package for 4ti2 to work around this issue. (See <https://github.com/msys2/MINGW-packages/pull/26350>.)

Fixes #55.